### PR TITLE
build: ensure files are formatted before commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- prettier --check .


### PR DESCRIPTION
This introduces a pre-commit hook that runs prettier in check mode